### PR TITLE
Modify models.py files in order to use just __str__ to avoid dupes

### DIFF
--- a/apps/levels/models.py
+++ b/apps/levels/models.py
@@ -1,9 +1,12 @@
+from __future__ import unicode_literals
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 
 from apps.skills.models import Skill
 from apps.contacts.models import Contact
 
 
+@python_2_unicode_compatible
 class Level(models.Model):
     name = models.CharField(max_length=200)
     alias = models.CharField(max_length=200, default='', blank=True)
@@ -13,9 +16,6 @@ class Level(models.Model):
     def __str__(self):
         return self.name
 
-    def __unicode__(self):
-        return '%s' % self.name
-
     class Meta:
         ordering = ('name',)
         app_label = 'levels'
@@ -24,6 +24,7 @@ class Level(models.Model):
         verbose_name_plural = 'Levels'
 
 
+@python_2_unicode_compatible
 class LevelSkill(models.Model):
     level = models.ForeignKey(Level, related_name='_level')
     skill = models.ForeignKey(Skill, related_name='_skill')
@@ -31,7 +32,4 @@ class LevelSkill(models.Model):
     from_date = models.DateField(null=True, blank=True)
 
     def __str__(self):
-        return "%s has the level %s in skill %s from %s" % (self.contact, self.level, self.skill, self.from_date)
-
-    def __unicode__(self):
         return "%s has the level %s in skill %s from %s" % (self.contact, self.level, self.skill, self.from_date)

--- a/apps/projects/models.py
+++ b/apps/projects/models.py
@@ -1,8 +1,11 @@
+from __future__ import unicode_literals
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 
 from apps.companies.models import Company
 
 
+@python_2_unicode_compatible
 class Project(models.Model):
     name = models.CharField(max_length=200)
     client = models.ForeignKey(Company, related_name='companies', related_query_name='company')
@@ -10,11 +13,8 @@ class Project(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     modified_at = models.DateTimeField(auto_now=True)
 
-    def __str__(self):  # __unicode__ on Python 2
+    def __str__(self):
         return self.name
-
-    def __unicode__(self):
-        return '%s' % self.name
 
     class Meta:
         ordering = ('created_at',)

--- a/apps/skills/models.py
+++ b/apps/skills/models.py
@@ -1,16 +1,16 @@
+from __future__ import unicode_literals
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 
 
+@python_2_unicode_compatible
 class Skill(models.Model):
     name = models.CharField(max_length=200)
     alias = models.CharField(max_length=200, default='', blank=True)
     active = models.BooleanField(default=True)
 
-    def __str__(self):  # __unicode__ on Python 2
+    def __str__(self):
         return self.name
-
-    def __unicode__(self):
-        return '%s' % self.name
 
     class Meta:
         ordering = ('name',)


### PR DESCRIPTION
This is the suggested way for Django porting to 3.0, it helps to avoid **str** and **unicode** duplicate functionality and also it's easy to maintain.
